### PR TITLE
Add Claude Code project setup with plugins and conventions

### DIFF
--- a/.claude/hooks/check-plugins.sh
+++ b/.claude/hooks/check-plugins.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# check-plugins.sh — Ensures required plugin marketplaces are registered.
+# Runs on SessionStart. stdout is injected into Claude's context.
+# Project-level settings.json handles plugin enablement; this script ensures
+# the marketplaces are available so those plugins can actually load.
+
+KNOWN_MARKETPLACES_FILE="$HOME/.claude/plugins/known_marketplaces.json"
+
+MISSING=()
+AUTO_INSTALLED=()
+
+check_marketplace() {
+  local name="$1"
+  local repo="$2"
+
+  if [ -f "$KNOWN_MARKETPLACES_FILE" ] && grep -q "\"$name\"" "$KNOWN_MARKETPLACES_FILE" 2>/dev/null; then
+    return 0
+  fi
+
+  # Try to auto-register
+  if command -v claude &>/dev/null; then
+    if claude plugin marketplace add "$repo" 2>/dev/null; then
+      AUTO_INSTALLED+=("$name")
+      return 0
+    fi
+  fi
+
+  MISSING+=("$name — run: claude plugin marketplace add $repo")
+  return 1
+}
+
+check_marketplace "voltagent-subagents" "VoltAgent/awesome-claude-code-subagents"
+check_marketplace "superpowers-marketplace" "obra/superpowers-marketplace"
+
+# --- Output (stdout → injected into Claude context) ---
+
+if [ ${#AUTO_INSTALLED[@]} -gt 0 ]; then
+  echo "SessionStart: Auto-registered plugin marketplaces: ${AUTO_INSTALLED[*]}"
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "SessionStart: WARNING — Missing required plugin marketplaces for this project."
+  echo "Please run the following commands and restart your session:"
+  echo ""
+  for m in "${MISSING[@]}"; do
+    echo "  $m"
+  done
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "enabledPlugins": {
+    "superpowers@superpowers-marketplace": true,
+    "voltagent-core-dev@voltagent-subagents": true,
+    "voltagent-qa-sec@voltagent-subagents": true,
+    "voltagent-lang@voltagent-subagents": true,
+    "voltagent-infra@voltagent-subagents": true,
+    "voltagent-data-ai@voltagent-subagents": true,
+    "voltagent-dev-exp@voltagent-subagents": true,
+    "voltagent-domains@voltagent-subagents": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-plugins.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+.next/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Screenshots (use tmp/screenshots/ only)
+tmp/
+
+# Test coverage
+coverage/
+
+# Logs
+*.log
+npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# Sailing Itinerary - Project Guidelines
+
+## Critical Rules
+
+- **Git: NEVER commit to main.** Feature branches + PRs only.
+- **Screenshots:** Always `tmp/screenshots/` (gitignored). Never repo root or `packages/`.
+
+## TDD Workflow (Mandatory)
+
+1. Write tests first (Vitest unit, Playwright e2e)
+2. Run tests, confirm they fail
+3. Implement minimum code to pass
+4. Refactor while tests stay green
+
+## Workflow
+
+- Enter plan mode for non-trivial tasks (3+ steps)
+- If something goes sideways, **STOP and re-plan**
+- Use subagents to keep main context clean
+- Never mark a task complete without proving it works
+- Track work in `tasks/todo.md`, PRs reference issue numbers
+
+## Error Corrections
+
+- Check `tasks/lessons.md` before starting work — it captures past mistakes so they don't repeat
+- After any correction, update `tasks/lessons.md`
+
+## GitHub Issues
+
+- Always use GitHub issues as the source of truth for all work
+- It is your responsibility to maintain issues (create, update, close)
+
+## Project Structure
+
+```
+.claude/rules/       # Architecture patterns (glob-matched, loaded when touching relevant files)
+research/            # Research documents
+docs/plans/          # Implementation plans
+wireframes/html/     # Wireframes
+tasks/todo.md        # Work tracking
+tasks/lessons.md     # Lessons learned from past mistakes
+tmp/screenshots/     # Screenshots (gitignored)
+```

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,3 @@
+# Lessons Learned
+
+<!-- Check this file before starting work. Update after any correction. -->

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,3 @@
+# TODO
+
+<!-- Track work items here. PRs should reference GitHub issue numbers. -->


### PR DESCRIPTION
## Summary
- Enables superpowers and VoltAgent subagent plugins for all developers via project-level `.claude/settings.json`
- Adds SessionStart hook that auto-registers missing plugin marketplaces (or warns with exact commands)
- Adds `CLAUDE.md` with team conventions: TDD workflow, feature branches only, plan mode, GitHub issues as source of truth

## Test plan
- [x] Hook outputs nothing when marketplaces are already registered
- [x] Hook auto-registers missing marketplaces via `claude plugin marketplace add`
- [x] Hook warns with exact commands when auto-registration fails
- [x] Project settings enable all 8 plugins (superpowers + 7 VoltAgent bundles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)