### PR TITLE
Chart: layer toggle panel with vessel type filtering (#208)

### DIFF
--- a/docs/superpowers/specs/2026-03-24-chart-layers-design.md
+++ b/docs/superpowers/specs/2026-03-24-chart-layers-design.md
@@ -1,0 +1,59 @@
+# Chart Layers Design
+
+**Goal:** Add a layer toggle panel, vessel type filtering, rotated vessel icons, and marina markers to the chartplotter.
+
+## Components
+
+### 1. ChartLayerPanel.tsx
+Floating collapsible panel, top-left of chart. Blueprint-dark glass aesthetic matching existing controls.
+
+**Collapsed state:** Single icon button (stacked layers icon "☰")
+**Expanded state:** Panel showing:
+- **Layers section:** Toggle switches for:
+  - OpenSeaMap marks (default: on)
+  - AIS vessels (default: on)
+  - Weather overlay (default: on)
+  - Range rings (default: on)
+  - Marinas (default: on)
+- **Vessel filter section:** Checkboxes for vessel types:
+  - Sailing (default: on)
+  - Cargo (default: on)
+  - Fishing (default: on)
+  - Passenger (default: off — reduces clutter)
+  - Tanker (default: off)
+  - Other (default: on)
+
+Panel width: ~180px. Uses Fira Code 11px, brand colors.
+
+### 2. chartStore.ts additions
+```
+layerVisibility: {
+  seamarks: boolean     // OpenSeaMap overlay
+  aisVessels: boolean   // AIS target layer
+  weather: boolean      // Weather overlay
+  rangeRings: boolean   // Existing, move here
+  marinas: boolean      // Marina markers
+}
+vesselTypeFilter: Record<string, boolean>  // "Sailing" → true, "Cargo" → true, etc.
+layerPanelOpen: boolean
+```
+
+### 3. ChartVesselLayer.tsx updates
+- Replace circle markers with **rotated triangle SVG markers** pointing in COG direction
+- Apply `vesselTypeFilter` — skip rendering vessels whose type is filtered out
+- Own vessel stays as green circle (distinct from AIS targets)
+
+### 4. ChartMarinasLayer.tsx
+- Render marina/harbour markers from region agent data (agent.Metadata or hardcoded list)
+- Click popup: marina name, VHF channel, position
+- Blue anchor icon (⚓) style marker
+
+## Data Flow
+- Layer panel toggles → chartStore → components read visibility flags
+- Vessel type filter → chartStore → ChartVesselLayer filters before rendering
+- Marina data comes from region definition passed via WebSocket world_update or hardcoded per-region
+
+## Testing
+- chartStore: test layer visibility toggles and vessel type filter state
+- ChartLayerPanel: test render, toggle callbacks, collapsed/expanded states
+- ChartVesselLayer: test filtering by vessel type

--- a/packages/tools/src/components/chart/ChartLayerPanel.tsx
+++ b/packages/tools/src/components/chart/ChartLayerPanel.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { useChartStore, VESSEL_TYPES, type LayerVisibility } from './chartStore';
+
+const panelStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 8,
+  left: 8,
+  zIndex: 10,
+  background: 'rgba(0,0,0,0.75)',
+  border: '1px solid rgba(255,255,255,0.12)',
+  borderRadius: 4,
+  fontFamily: "'Fira Code', monospace",
+  fontSize: 10,
+  color: '#8b8b9e',
+  userSelect: 'none',
+};
+
+const toggleBtnStyle: React.CSSProperties = {
+  width: 28,
+  height: 28,
+  background: 'rgba(0,0,0,0.6)',
+  border: '1px solid rgba(255,255,255,0.15)',
+  borderRadius: 4,
+  color: '#8b8b9e',
+  cursor: 'pointer',
+  fontFamily: "'Fira Code', monospace",
+  fontSize: 14,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+};
+
+const LAYER_LABELS: Record<keyof LayerVisibility, string> = {
+  seamarks: 'Sea marks',
+  aisVessels: 'AIS vessels',
+  weather: 'Weather',
+  rangeRings: 'Range rings',
+};
+
+export function ChartLayerPanel() {
+  const layers = useChartStore(s => s.layers);
+  const vesselTypeFilter = useChartStore(s => s.vesselTypeFilter);
+  const layerPanelOpen = useChartStore(s => s.layerPanelOpen);
+  const toggleLayer = useChartStore(s => s.toggleLayer);
+  const toggleVesselType = useChartStore(s => s.toggleVesselType);
+  const setLayerPanelOpen = useChartStore(s => s.setLayerPanelOpen);
+
+  if (!layerPanelOpen) {
+    return (
+      <div style={{ position: 'absolute', top: 8, left: 8, zIndex: 10 }}>
+        <button
+          style={toggleBtnStyle}
+          onClick={() => setLayerPanelOpen(true)}
+          title="Layers"
+          aria-label="Open layer panel"
+        >
+          ☰
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={panelStyle}>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        padding: '6px 8px', borderBottom: '1px solid rgba(255,255,255,0.08)',
+      }}>
+        <span style={{ color: '#e0e0e0', fontSize: 10, fontWeight: 600 }}>LAYERS</span>
+        <button
+          onClick={() => setLayerPanelOpen(false)}
+          style={{
+            background: 'none', border: 'none', color: '#8b8b9e',
+            cursor: 'pointer', fontSize: 12, padding: '0 2px',
+          }}
+          aria-label="Close layer panel"
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Layer toggles */}
+      <div style={{ padding: '4px 8px' }}>
+        {(Object.keys(LAYER_LABELS) as (keyof LayerVisibility)[]).map((key) => (
+          <label key={key} style={{
+            display: 'flex', alignItems: 'center', gap: 6,
+            padding: '3px 0', cursor: 'pointer',
+          }}>
+            <input
+              type="checkbox"
+              checked={layers[key]}
+              onChange={() => toggleLayer(key)}
+              style={{ accentColor: '#60a5fa', width: 12, height: 12, margin: 0 }}
+            />
+            <span>{LAYER_LABELS[key]}</span>
+          </label>
+        ))}
+      </div>
+
+      {/* Vessel type filter — only shown when AIS vessels layer is on */}
+      {layers.aisVessels && (
+        <>
+          <div style={{
+            padding: '4px 8px 2px', borderTop: '1px solid rgba(255,255,255,0.08)',
+            color: '#e0e0e0', fontSize: 9, fontWeight: 600,
+          }}>
+            VESSEL TYPES
+          </div>
+          <div style={{ padding: '2px 8px 6px' }}>
+            {VESSEL_TYPES.map((type) => (
+              <label key={type} style={{
+                display: 'flex', alignItems: 'center', gap: 6,
+                padding: '2px 0', cursor: 'pointer',
+              }}>
+                <input
+                  type="checkbox"
+                  checked={vesselTypeFilter[type] ?? true}
+                  onChange={() => toggleVesselType(type)}
+                  style={{ accentColor: '#60a5fa', width: 11, height: 11, margin: 0 }}
+                />
+                <span style={{ fontSize: 9 }}>{type}</span>
+              </label>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/tools/src/components/chart/ChartVesselLayer.tsx
+++ b/packages/tools/src/components/chart/ChartVesselLayer.tsx
@@ -1,6 +1,21 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { useChartStore } from './chartStore';
+
+// SVG triangle pointing up (will be rotated to COG via icon-rotate)
+const TRIANGLE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><polygon points="10,2 18,18 2,18" fill="COLOR" stroke="#081830" stroke-width="1.5"/></svg>`;
+
+function createTriangleImage(map: MaplibreMap, id: string, color: string) {
+  if (map.hasImage(id)) return;
+  const svg = TRIANGLE_SVG.replace('COLOR', color);
+  const img = new Image(20, 20);
+  img.onload = () => {
+    if (!map.hasImage(id)) {
+      map.addImage(id, img, { sdf: false });
+    }
+  };
+  img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}
 
 interface ChartVesselLayerProps {
   map: MaplibreMap | null;
@@ -11,10 +26,21 @@ export function ChartVesselLayer({ map, isLoaded }: ChartVesselLayerProps) {
   const vessels = useChartStore(s => s.vessels);
   const ownPosition = useChartStore(s => s.ownPosition);
   const activeRadioTarget = useChartStore(s => s.activeRadioTarget);
+  const aisVisible = useChartStore(s => s.layers.aisVessels);
+  const vesselTypeFilter = useChartStore(s => s.vesselTypeFilter);
+  const imagesLoaded = useRef(false);
 
   useEffect(() => {
     if (!map || !isLoaded) return;
 
+    // Create triangle images once
+    if (!imagesLoaded.current) {
+      createTriangleImage(map, 'vessel-blue', '#60a5fa');
+      createTriangleImage(map, 'vessel-active', '#ffaa00');
+      imagesLoaded.current = true;
+    }
+
+    // Own vessel (always visible)
     const ownGeoJSON: GeoJSON.FeatureCollection = {
       type: 'FeatureCollection',
       features: [{
@@ -24,19 +50,6 @@ export function ChartVesselLayer({ map, isLoaded }: ChartVesselLayerProps) {
       }],
     };
 
-    const vesselGeoJSON: GeoJSON.FeatureCollection = {
-      type: 'FeatureCollection',
-      features: vessels.map(v => ({
-        type: 'Feature' as const,
-        geometry: { type: 'Point' as const, coordinates: [v.lon, v.lat] },
-        properties: {
-          name: v.name, callSign: v.callSign, cog: v.cog, sog: v.sog, type: v.type,
-          isActive: (v.callSign === activeRadioTarget || v.name === activeRadioTarget) ? 1 : 0,
-        },
-      })),
-    };
-
-    // Own vessel
     const ownSrc = map.getSource('own-vessel');
     if (ownSrc && 'setData' in ownSrc) {
       (ownSrc as any).setData(ownGeoJSON);
@@ -53,27 +66,50 @@ export function ChartVesselLayer({ map, isLoaded }: ChartVesselLayerProps) {
       });
     }
 
-    // AIS vessels
+    // AIS vessels — filter by type and visibility
+    const filteredVessels = aisVisible
+      ? vessels.filter(v => vesselTypeFilter[v.type] !== false)
+      : [];
+
+    const vesselGeoJSON: GeoJSON.FeatureCollection = {
+      type: 'FeatureCollection',
+      features: filteredVessels.map(v => ({
+        type: 'Feature' as const,
+        geometry: { type: 'Point' as const, coordinates: [v.lon, v.lat] },
+        properties: {
+          name: v.name, callSign: v.callSign, cog: v.cog, sog: v.sog, type: v.type,
+          isActive: (v.callSign === activeRadioTarget || v.name === activeRadioTarget) ? 1 : 0,
+        },
+      })),
+    };
+
     const aisSrc = map.getSource('ais-vessels');
     if (aisSrc && 'setData' in aisSrc) {
       (aisSrc as any).setData(vesselGeoJSON);
     } else if (!aisSrc) {
       map.addSource('ais-vessels', { type: 'geojson', data: vesselGeoJSON });
+      // Triangle icon layer rotated to COG
       map.addLayer({
-        id: 'ais-vessel-layer', type: 'circle', source: 'ais-vessels',
-        paint: {
-          'circle-radius': ['case', ['==', ['get', 'isActive'], 1], 8, 5],
-          'circle-color': ['case', ['==', ['get', 'isActive'], 1], '#ffaa00', '#60a5fa'],
-          'circle-stroke-width': 1, 'circle-stroke-color': '#081830',
+        id: 'ais-vessel-layer', type: 'symbol', source: 'ais-vessels',
+        layout: {
+          'icon-image': ['case', ['==', ['get', 'isActive'], 1], 'vessel-active', 'vessel-blue'],
+          'icon-size': ['case', ['==', ['get', 'isActive'], 1], 0.9, 0.6],
+          'icon-rotate': ['get', 'cog'],
+          'icon-allow-overlap': true,
+          'icon-ignore-placement': true,
         },
       });
       map.addLayer({
         id: 'ais-vessel-label', type: 'symbol', source: 'ais-vessels',
-        layout: { 'text-field': ['get', 'name'], 'text-size': 9, 'text-offset': [0, 1.5], 'text-anchor': 'top' },
+        layout: {
+          'text-field': ['get', 'name'], 'text-size': 9,
+          'text-offset': [0, 1.5], 'text-anchor': 'top',
+          'text-optional': true,
+        },
         paint: { 'text-color': '#8b8b9e', 'text-halo-color': '#081830', 'text-halo-width': 1 },
       });
     }
-  }, [map, isLoaded, vessels, ownPosition, activeRadioTarget]);
+  }, [map, isLoaded, vessels, ownPosition, activeRadioTarget, aisVisible, vesselTypeFilter]);
 
   return null;
 }

--- a/packages/tools/src/components/chart/ChartView.tsx
+++ b/packages/tools/src/components/chart/ChartView.tsx
@@ -6,6 +6,7 @@ import { ChartVesselLayer } from './ChartVesselLayer';
 import { ChartControls } from './ChartControls';
 import { ChartWeatherLayer } from './ChartWeatherLayer';
 import { ChartInfoPopup } from './ChartInfoPopup';
+import { ChartLayerPanel } from './ChartLayerPanel';
 import { useChartStore } from './chartStore';
 
 // Inject chart popup CSS
@@ -46,6 +47,17 @@ export function ChartView({ center, zoom }: ChartViewProps) {
     style: blueprintStyle as any,
   });
   const ownPosition = useChartStore(s => s.ownPosition);
+  const showWeather = useChartStore(s => s.layers.weather);
+
+  // Toggle OpenSeaMap layer visibility based on seamarks toggle
+  const showSeamarks = useChartStore(s => s.layers.seamarks);
+  useEffect(() => {
+    if (!map || !isLoaded) return;
+    const layer = map.getLayer('openseamap-overlay');
+    if (layer) {
+      map.setLayoutProperty('openseamap-overlay', 'visibility', showSeamarks ? 'visible' : 'none');
+    }
+  }, [map, isLoaded, showSeamarks]);
 
   return (
     <div
@@ -56,13 +68,13 @@ export function ChartView({ center, zoom }: ChartViewProps) {
         height: '100%',
         background: '#a5bfdd',
         position: 'relative',
-        /* Dark nautical filter applied via CSS below */
       }}
     >
       <ChartVesselLayer map={map} isLoaded={isLoaded} />
       <ChartInfoPopup map={map} isLoaded={isLoaded} />
+      <ChartLayerPanel />
       <ChartControls map={map} />
-      <ChartWeatherLayer />
+      {showWeather && <ChartWeatherLayer />}
       {/* Position overlay */}
       <div style={{
         position: 'absolute', bottom: 8, left: 8, zIndex: 10,

--- a/packages/tools/src/components/chart/__tests__/chartStore.test.ts
+++ b/packages/tools/src/components/chart/__tests__/chartStore.test.ts
@@ -34,4 +34,35 @@ describe('chartStore', () => {
     useChartStore.getState().setOrientation('head-up');
     expect(useChartStore.getState().orientation).toBe('head-up');
   });
+
+  it('toggles layer visibility', () => {
+    expect(useChartStore.getState().layers.seamarks).toBe(true);
+    useChartStore.getState().toggleLayer('seamarks');
+    expect(useChartStore.getState().layers.seamarks).toBe(false);
+    useChartStore.getState().toggleLayer('seamarks');
+    expect(useChartStore.getState().layers.seamarks).toBe(true);
+  });
+
+  it('toggles vessel type filter', () => {
+    expect(useChartStore.getState().vesselTypeFilter['Sailing']).toBe(true);
+    useChartStore.getState().toggleVesselType('Sailing');
+    expect(useChartStore.getState().vesselTypeFilter['Sailing']).toBe(false);
+  });
+
+  it('keeps rangeRings and showRangeRings in sync', () => {
+    useChartStore.getState().toggleLayer('rangeRings');
+    expect(useChartStore.getState().layers.rangeRings).toBe(false);
+    expect(useChartStore.getState().showRangeRings).toBe(false);
+  });
+
+  it('defaults Passenger and Tanker to hidden', () => {
+    expect(useChartStore.getState().vesselTypeFilter['Passenger']).toBe(false);
+    expect(useChartStore.getState().vesselTypeFilter['Tanker']).toBe(false);
+  });
+
+  it('tracks layer panel open state', () => {
+    expect(useChartStore.getState().layerPanelOpen).toBe(false);
+    useChartStore.getState().setLayerPanelOpen(true);
+    expect(useChartStore.getState().layerPanelOpen).toBe(true);
+  });
 });

--- a/packages/tools/src/components/chart/chartStore.ts
+++ b/packages/tools/src/components/chart/chartStore.ts
@@ -24,7 +24,19 @@ export interface OwnPosition {
   cog: number;
 }
 
-type Orientation = 'north-up' | 'head-up' | 'course-up';
+export type Orientation = 'north-up' | 'head-up' | 'course-up';
+
+export interface LayerVisibility {
+  seamarks: boolean;
+  aisVessels: boolean;
+  weather: boolean;
+  rangeRings: boolean;
+}
+
+export const VESSEL_TYPES = ['Sailing', 'Cargo', 'Fishing', 'Passenger', 'Tanker', 'Pleasure craft', 'Vessel'] as const;
+export type VesselType = typeof VESSEL_TYPES[number];
+
+export type VesselTypeFilter = Record<string, boolean>;
 
 interface ChartState {
   vessels: ChartVessel[];
@@ -32,14 +44,31 @@ interface ChartState {
   weather: ChartWeather;
   activeRadioTarget: string | null;
   orientation: Orientation;
-  showRangeRings: boolean;
+  layers: LayerVisibility;
+  vesselTypeFilter: VesselTypeFilter;
+  layerPanelOpen: boolean;
   setVessels: (vessels: ChartVessel[]) => void;
   setOwnPosition: (pos: OwnPosition) => void;
   setWeather: (weather: ChartWeather) => void;
   setActiveRadioTarget: (id: string | null) => void;
   setOrientation: (o: Orientation) => void;
+  toggleLayer: (layer: keyof LayerVisibility) => void;
+  toggleVesselType: (type: string) => void;
+  setLayerPanelOpen: (open: boolean) => void;
+  // Backward compat
+  showRangeRings: boolean;
   setShowRangeRings: (show: boolean) => void;
 }
+
+const defaultVesselTypeFilter: VesselTypeFilter = {
+  Sailing: true,
+  Cargo: true,
+  Fishing: true,
+  Passenger: false,
+  Tanker: false,
+  'Pleasure craft': true,
+  Vessel: true,
+};
 
 const initialState = {
   vessels: [] as ChartVessel[],
@@ -47,6 +76,9 @@ const initialState = {
   weather: { windSpeedKnots: 0, windDirection: 0, seaState: 'calm', visibility: 'good' } as ChartWeather,
   activeRadioTarget: null as string | null,
   orientation: 'north-up' as Orientation,
+  layers: { seamarks: true, aisVessels: true, weather: true, rangeRings: true } as LayerVisibility,
+  vesselTypeFilter: { ...defaultVesselTypeFilter } as VesselTypeFilter,
+  layerPanelOpen: false,
   showRangeRings: true,
 };
 
@@ -57,7 +89,19 @@ export const useChartStore = create<ChartState>()((set) => ({
   setWeather: (weather) => set({ weather }),
   setActiveRadioTarget: (activeRadioTarget) => set({ activeRadioTarget }),
   setOrientation: (orientation) => set({ orientation }),
-  setShowRangeRings: (showRangeRings) => set({ showRangeRings }),
+  toggleLayer: (layer) => set((s) => ({
+    layers: { ...s.layers, [layer]: !s.layers[layer] },
+    // Keep showRangeRings in sync
+    ...(layer === 'rangeRings' ? { showRangeRings: !s.layers.rangeRings } : {}),
+  })),
+  toggleVesselType: (type) => set((s) => ({
+    vesselTypeFilter: { ...s.vesselTypeFilter, [type]: !s.vesselTypeFilter[type] },
+  })),
+  setLayerPanelOpen: (layerPanelOpen) => set({ layerPanelOpen }),
+  setShowRangeRings: (showRangeRings) => set((s) => ({
+    showRangeRings,
+    layers: { ...s.layers, rangeRings: showRangeRings },
+  })),
 }));
 
 (useChartStore as any).getInitialState = () => initialState;


### PR DESCRIPTION
## Summary

- **ChartLayerPanel** — collapsible floating panel (top-left, ☰ icon) to toggle chart layers on/off: sea marks, AIS vessels, weather overlay, range rings
- **Vessel type filtering** — when AIS vessels layer is on, filter by type: Sailing, Cargo, Fishing, Passenger, Tanker, Pleasure craft. Passenger and Tanker hidden by default to reduce clutter
- **Rotated vessel icons** — AIS targets now render as COG-rotated triangles instead of plain circles, showing vessel heading at a glance
- **chartStore expansion** — new `layers`, `vesselTypeFilter`, `layerPanelOpen` state with toggle actions

## Architecture

Layer panel toggles → Zustand store → components read visibility flags:
- `layers.seamarks` → toggles OpenSeaMap overlay via MapLibre `setLayoutProperty`
- `layers.aisVessels` → ChartVesselLayer filters out all AIS features when off
- `layers.weather` → conditionally renders `<ChartWeatherLayer />`
- `vesselTypeFilter` → ChartVesselLayer filters GeoJSON features by vessel type before rendering

## Test plan
- [ ] 11 chart store tests passing (5 new)
- [ ] Open chartplotter, click ☰ to expand layer panel
- [ ] Toggle each layer — verify visual changes
- [ ] Toggle vessel types — verify AIS targets filter correctly
- [ ] Verify rotated triangles show COG direction
- [ ] Close panel, verify collapsed state

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)