### PR TITLE
Chart: Pacific-centered global view for circumnavigation planning

### DIFF
--- a/packages/tools/src/components/chart/useMap.ts
+++ b/packages/tools/src/components/chart/useMap.ts
@@ -21,6 +21,7 @@ export function useMap({ container, center = [-5.04, 50.09], zoom = 12, style }:
       center,
       zoom,
       attributionControl: false,
+      renderWorldCopies: true,
     });
 
     map.on('load', () => setIsLoaded(true));

--- a/packages/tools/src/pages/tools/chart.astro
+++ b/packages/tools/src/pages/tools/chart.astro
@@ -4,5 +4,6 @@ import { ChartView } from '@/components/chart/ChartView';
 export const prerender = false;
 ---
 <MFDLayout title="Chart — Above Deck" screenId="chart">
-  <ChartView client:only="react" />
+  <!-- Pacific-centered global view for circumnavigation planning -->
+  <ChartView client:only="react" center={[170, 10]} zoom={2} />
 </MFDLayout>


### PR DESCRIPTION
## Summary

The standalone chart page (`/tools/chart`) now opens at a global view centered on the Pacific Ocean (170°E, 10°N at zoom 2), not zoomed into Cornwall.

Sailors planning circumnavigation see the world differently from Google Maps — the Pacific is central, not split at the edges. Trade wind routes, canal passages (Panama, Suez), and seasonal weather windows all make more sense when the Pacific is your reference frame.

**Changes:**
- Chart page starts at zoom 2 centered on 170°E (Pacific-centered world view)
- `renderWorldCopies: true` enables smooth scrolling past the antimeridian
- VHF simulator chart view is unchanged (still centers on session region)

## Test plan
- [ ] Open `/tools/chart` — see full world map, Pacific-centered
- [ ] Scroll/drag past 180° — map wraps smoothly
- [ ] Zoom in to any area — nautical details appear at higher zoom levels
- [ ] VHF sim chart still centers on region (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)