### PR TITLE
Chart: nautical POI layer — marinas, anchorages, fuel from OpenStreetMap

### DIFF
--- a/packages/tools/src/components/chart/ChartPOILayer.tsx
+++ b/packages/tools/src/components/chart/ChartPOILayer.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useCallback } from 'react';
+import type { Map as MaplibreMap } from 'maplibre-gl';
+import maplibregl from 'maplibre-gl';
+import { fetchNauticalPOIs, type NauticalPOI, type POIType } from '@/lib/chart/overpass';
+
+const POI_ICONS: Record<POIType, string> = {
+  marina: '⚓',
+  harbour: '🏗',
+  anchorage: '⚓',
+  fuel: '⛽',
+  boatyard: '🔧',
+  slipway: '🛥',
+};
+
+const POI_COLORS: Record<POIType, string> = {
+  marina: '#60a5fa',
+  harbour: '#60a5fa',
+  anchorage: '#4ade80',
+  fuel: '#f87171',
+  boatyard: '#8b8b9e',
+  slipway: '#8b8b9e',
+};
+
+interface ChartPOILayerProps {
+  map: MaplibreMap | null;
+  isLoaded: boolean;
+  visible?: boolean;
+}
+
+export function ChartPOILayer({ map, isLoaded, visible = true }: ChartPOILayerProps) {
+  const poisRef = useRef<NauticalPOI[]>([]);
+  const popupRef = useRef<maplibregl.Popup | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const lastBboxRef = useRef('');
+
+  const loadPOIs = useCallback(async () => {
+    if (!map || !visible) return;
+
+    const bounds = map.getBounds();
+    const zoom = map.getZoom();
+
+    // Only fetch at zoom >= 8 (POIs are meaningless at global zoom)
+    if (zoom < 8) {
+      updateSource(map, []);
+      return;
+    }
+
+    // Avoid re-fetching for the same area
+    const bboxKey = [
+      bounds.getSouth().toFixed(2), bounds.getWest().toFixed(2),
+      bounds.getNorth().toFixed(2), bounds.getEast().toFixed(2),
+    ].join(',');
+    if (bboxKey === lastBboxRef.current) return;
+    lastBboxRef.current = bboxKey;
+
+    // Cancel previous request
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const pois = await fetchNauticalPOIs(
+        bounds.getSouth(), bounds.getWest(),
+        bounds.getNorth(), bounds.getEast(),
+        controller.signal,
+      );
+      poisRef.current = pois;
+      updateSource(map, pois);
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        console.warn('[POI] Overpass query failed:', e.message);
+      }
+    }
+  }, [map, visible]);
+
+  // Set up source and load on map events
+  useEffect(() => {
+    if (!map || !isLoaded) return;
+
+    // Create GeoJSON source if not exists
+    if (!map.getSource('nautical-pois')) {
+      map.addSource('nautical-pois', {
+        type: 'geojson',
+        data: { type: 'FeatureCollection', features: [] },
+      });
+      map.addLayer({
+        id: 'poi-labels', type: 'symbol', source: 'nautical-pois',
+        layout: {
+          'text-field': ['concat', ['get', 'icon'], ' ', ['get', 'name']],
+          'text-size': 11,
+          'text-anchor': 'left',
+          'text-offset': [0.5, 0],
+          'text-allow-overlap': false,
+          'text-optional': true,
+        },
+        paint: {
+          'text-color': ['get', 'color'],
+          'text-halo-color': '#081830',
+          'text-halo-width': 1.5,
+        },
+      });
+    }
+
+    // Load POIs on map idle (after pan/zoom)
+    const onIdle = () => loadPOIs();
+    map.on('moveend', onIdle);
+    loadPOIs(); // Initial load
+
+    // Click handler for POI popups
+    const onClick = (e: any) => {
+      const features = map.queryRenderedFeatures(e.point, { layers: ['poi-labels'] });
+      if (!features.length) return;
+
+      const props = features[0].properties;
+      const coords = (features[0].geometry as any).coordinates;
+
+      popupRef.current?.remove();
+      popupRef.current = new maplibregl.Popup({ closeButton: true, maxWidth: '220px' })
+        .setLngLat(coords)
+        .setHTML(buildPopupHTML(props))
+        .addTo(map);
+    };
+    map.on('click', 'poi-labels', onClick);
+
+    // Cursor style
+    map.on('mouseenter', 'poi-labels', () => { map.getCanvas().style.cursor = 'pointer'; });
+    map.on('mouseleave', 'poi-labels', () => { map.getCanvas().style.cursor = ''; });
+
+    return () => {
+      map.off('moveend', onIdle);
+      map.off('click', 'poi-labels', onClick);
+      abortRef.current?.abort();
+      popupRef.current?.remove();
+    };
+  }, [map, isLoaded, loadPOIs]);
+
+  // Toggle visibility
+  useEffect(() => {
+    if (!map || !isLoaded) return;
+    const layer = map.getLayer('poi-labels');
+    if (layer) {
+      map.setLayoutProperty('poi-labels', 'visibility', visible ? 'visible' : 'none');
+    }
+    if (visible) loadPOIs();
+  }, [map, isLoaded, visible, loadPOIs]);
+
+  return null;
+}
+
+function updateSource(map: MaplibreMap, pois: NauticalPOI[]) {
+  const src = map.getSource('nautical-pois');
+  if (!src || !('setData' in src)) return;
+
+  (src as any).setData({
+    type: 'FeatureCollection',
+    features: pois.map(poi => ({
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [poi.lon, poi.lat] },
+      properties: {
+        name: poi.name,
+        type: poi.type,
+        icon: POI_ICONS[poi.type] || '📍',
+        color: POI_COLORS[poi.type] || '#8b8b9e',
+        ...poi.tags,
+      },
+    })),
+  });
+}
+
+function buildPopupHTML(props: any): string {
+  const type = props.type as string;
+  const icon = POI_ICONS[type as POIType] || '📍';
+  const lines: string[] = [];
+
+  lines.push(`<div style="padding:8px;font-family:'Fira Code',monospace;font-size:11px;color:#e0e0e0;background:#16213e;border-radius:4px;">`);
+  lines.push(`<div style="font-weight:700;margin-bottom:4px;">${icon} ${props.name || 'Unknown'}</div>`);
+  lines.push(`<div style="color:#8b8b9e;font-size:9px;text-transform:uppercase;margin-bottom:4px;">${type}</div>`);
+
+  if (props.vhf_channel || props['seamark:communication:vhf_channel']) {
+    const ch = props.vhf_channel || props['seamark:communication:vhf_channel'];
+    lines.push(`<div>VHF Ch ${ch}</div>`);
+  }
+  if (props.phone) {
+    lines.push(`<div style="color:#8b8b9e;">${props.phone}</div>`);
+  }
+  if (props.website) {
+    lines.push(`<div><a href="${props.website}" target="_blank" rel="noopener" style="color:#60a5fa;text-decoration:none;font-size:10px;">Website →</a></div>`);
+  }
+  if (props.opening_hours) {
+    lines.push(`<div style="color:#8b8b9e;font-size:9px;margin-top:2px;">${props.opening_hours}</div>`);
+  }
+  if (props.capacity) {
+    lines.push(`<div style="color:#8b8b9e;font-size:9px;">Berths: ${props.capacity}</div>`);
+  }
+
+  lines.push('</div>');
+  return lines.join('');
+}

--- a/packages/tools/src/components/chart/ChartView.tsx
+++ b/packages/tools/src/components/chart/ChartView.tsx
@@ -7,6 +7,7 @@ import { ChartControls } from './ChartControls';
 import { ChartWeatherLayer } from './ChartWeatherLayer';
 import { ChartInfoPopup } from './ChartInfoPopup';
 import { ChartLayerPanel } from './ChartLayerPanel';
+import { ChartPOILayer } from './ChartPOILayer';
 import { useChartStore } from './chartStore';
 
 // Inject chart popup CSS
@@ -73,6 +74,7 @@ export function ChartView({ center, zoom }: ChartViewProps) {
       <ChartVesselLayer map={map} isLoaded={isLoaded} />
       <ChartInfoPopup map={map} isLoaded={isLoaded} />
       <ChartLayerPanel />
+      <ChartPOILayer map={map} isLoaded={isLoaded} />
       <ChartControls map={map} />
       {showWeather && <ChartWeatherLayer />}
       {/* Position overlay */}

--- a/packages/tools/src/lib/chart/__tests__/overpass.test.ts
+++ b/packages/tools/src/lib/chart/__tests__/overpass.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchNauticalPOIs, type NauticalPOI } from '../overpass';
+
+const mockOverpassResponse = {
+  elements: [
+    {
+      type: 'node', id: 1001, lat: 50.15, lon: -5.07,
+      tags: { name: 'Falmouth Marina', leisure: 'marina', 'vhf_channel': '80' },
+    },
+    {
+      type: 'node', id: 1002, lat: 50.14, lon: -5.06,
+      tags: { name: 'Visitors Anchorage', 'seamark:type': 'anchorage' },
+    },
+    {
+      type: 'node', id: 1003, lat: 50.16, lon: -5.05,
+      tags: { amenity: 'fuel', boat: 'yes', name: 'Harbour Fuel Dock' },
+    },
+    {
+      type: 'way', id: 2001,
+      center: { lat: 50.17, lon: -5.08 },
+      tags: { name: 'Penryn Boatyard', waterway: 'boatyard' },
+    },
+    // Duplicate of Falmouth Marina (should be deduped)
+    {
+      type: 'node', id: 1004, lat: 50.1501, lon: -5.0701,
+      tags: { name: 'Falmouth Marina', leisure: 'marina' },
+    },
+    // Node with no lat/lon (should be filtered)
+    {
+      type: 'relation', id: 3001, tags: { name: 'Something' },
+    },
+  ],
+};
+
+describe('fetchNauticalPOIs', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses overpass response into NauticalPOI array', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockOverpassResponse),
+    }) as any;
+
+    const pois = await fetchNauticalPOIs(50, -5.1, 50.2, -5.0);
+
+    expect(pois).toHaveLength(4); // 5 valid - 1 duplicate = 4
+    expect(pois[0].name).toBe('Falmouth Marina');
+    expect(pois[0].type).toBe('marina');
+    expect(pois[1].type).toBe('anchorage');
+    expect(pois[2].type).toBe('fuel');
+    expect(pois[3].type).toBe('boatyard');
+  });
+
+  it('classifies POI types correctly', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockOverpassResponse),
+    }) as any;
+
+    const pois = await fetchNauticalPOIs(50, -5.1, 50.2, -5.0);
+    const types = pois.map(p => p.type);
+    expect(types).toContain('marina');
+    expect(types).toContain('anchorage');
+    expect(types).toContain('fuel');
+    expect(types).toContain('boatyard');
+  });
+
+  it('deduplicates by name and approximate position', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockOverpassResponse),
+    }) as any;
+
+    const pois = await fetchNauticalPOIs(50, -5.1, 50.2, -5.0);
+    const marinas = pois.filter(p => p.name === 'Falmouth Marina');
+    expect(marinas).toHaveLength(1);
+  });
+
+  it('handles way elements with center coordinates', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockOverpassResponse),
+    }) as any;
+
+    const pois = await fetchNauticalPOIs(50, -5.1, 50.2, -5.0);
+    const boatyard = pois.find(p => p.name === 'Penryn Boatyard');
+    expect(boatyard).toBeDefined();
+    expect(boatyard!.lat).toBe(50.17);
+  });
+
+  it('throws on API error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 429 }) as any;
+    await expect(fetchNauticalPOIs(50, -5, 51, -4)).rejects.toThrow('Overpass API error: 429');
+  });
+
+  it('returns empty array for empty response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ elements: [] }),
+    }) as any;
+
+    const pois = await fetchNauticalPOIs(50, -5, 51, -4);
+    expect(pois).toEqual([]);
+  });
+
+  it('passes abort signal to fetch', async () => {
+    const controller = new AbortController();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ elements: [] }),
+    }) as any;
+
+    await fetchNauticalPOIs(50, -5, 51, -4, controller.signal);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+});

--- a/packages/tools/src/lib/chart/overpass.ts
+++ b/packages/tools/src/lib/chart/overpass.ts
@@ -1,0 +1,94 @@
+/**
+ * Queries OpenStreetMap Overpass API for nautical points of interest.
+ * Returns marinas, anchorages, fuel stations, boatyards, and slipways
+ * within a given bounding box.
+ */
+
+const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+
+export interface NauticalPOI {
+  id: number;
+  lat: number;
+  lon: number;
+  name: string;
+  type: POIType;
+  tags: Record<string, string>;
+}
+
+export type POIType = 'marina' | 'anchorage' | 'fuel' | 'boatyard' | 'slipway' | 'harbour';
+
+/**
+ * Fetch nautical POIs within the given bounding box.
+ * Uses Overpass QL to query for relevant OSM features.
+ */
+export async function fetchNauticalPOIs(
+  south: number, west: number, north: number, east: number,
+  signal?: AbortSignal,
+): Promise<NauticalPOI[]> {
+  // Overpass QL: query marinas, harbours, anchorages, fuel, boatyards, slipways
+  const bbox = `${south},${west},${north},${east}`;
+  const query = `
+[out:json][timeout:10];
+(
+  node["leisure"="marina"](${bbox});
+  node["seamark:type"="harbour"](${bbox});
+  node["seamark:type"="anchorage"](${bbox});
+  node["amenity"="fuel"]["boat"="yes"](${bbox});
+  node["amenity"="fuel"]["seamark:type"](${bbox});
+  node["leisure"="slipway"](${bbox});
+  node["waterway"="boatyard"](${bbox});
+  way["leisure"="marina"](${bbox});
+  way["seamark:type"="harbour"](${bbox});
+);
+out center body;
+`.trim();
+
+  const resp = await fetch(OVERPASS_URL, {
+    method: 'POST',
+    body: `data=${encodeURIComponent(query)}`,
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    signal,
+  });
+
+  if (!resp.ok) {
+    throw new Error(`Overpass API error: ${resp.status}`);
+  }
+
+  const data = await resp.json();
+  return parseOverpassResponse(data);
+}
+
+function parseOverpassResponse(data: any): NauticalPOI[] {
+  if (!data.elements) return [];
+
+  const seen = new Set<string>();
+
+  return data.elements
+    .map((el: any) => {
+      const lat = el.lat ?? el.center?.lat;
+      const lon = el.lon ?? el.center?.lon;
+      if (!lat || !lon) return null;
+
+      const tags = el.tags || {};
+      const name = tags.name || tags['seamark:name'] || classifyType(tags);
+      const type = classifyType(tags);
+
+      // Deduplicate by name+approximate position
+      const key = `${name}-${lat.toFixed(3)}-${lon.toFixed(3)}`;
+      if (seen.has(key)) return null;
+      seen.add(key);
+
+      return { id: el.id, lat, lon, name, type, tags };
+    })
+    .filter(Boolean) as NauticalPOI[];
+}
+
+function classifyType(tags: Record<string, string>): POIType {
+  if (tags.leisure === 'marina') return 'marina';
+  if (tags.leisure === 'slipway') return 'slipway';
+  if (tags.waterway === 'boatyard') return 'boatyard';
+  if (tags['seamark:type'] === 'anchorage') return 'anchorage';
+  if (tags['seamark:type'] === 'harbour') return 'harbour';
+  if (tags.amenity === 'fuel') return 'fuel';
+  return 'harbour';
+}


### PR DESCRIPTION
## Summary

Adds a live nautical Points of Interest layer to the chartplotter, powered by OpenStreetMap's Overpass API. When you zoom in (≥8), the chart shows nearby marinas, anchorages, fuel docks, boatyards, and slipways — the "dumb storage" data that Google Maps has but a bare nautical chart doesn't.

**POI types shown:**
- ⚓ **Marinas** — name, VHF channel, berths, phone, website
- ⚓ **Anchorages** — marked from seamark data
- ⛽ **Fuel docks** — with opening hours when available
- 🔧 **Boatyards** — repair facilities
- 🛥 **Slipways** — launch points

**How it works:**
- Queries Overpass API on `moveend` at zoom ≥ 8
- Caches by bounding box — won't re-fetch if you haven't moved much
- Aborts in-flight requests when map pans (no stale data)
- Deduplicates by name + position
- Clickable popups with VHF channel, phone, website, hours, capacity

No API key needed. Free. All from OpenStreetMap community data.

## Test plan
- [ ] 7 Overpass tests passing (parse, classify, dedup, error, abort)
- [ ] Open chart, zoom into any harbour (e.g. Falmouth, Mallorca, St Martin)
- [ ] See marina/anchorage/fuel markers appear
- [ ] Click a marker — see popup with details
- [ ] Pan away — old POIs replaced with new ones
- [ ] Zoom out below 8 — POIs disappear (they'd be meaningless dots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)