### PR TITLE
Chart: bathymetry depth shading + POI layer toggle

### DIFF
--- a/packages/tools/src/components/chart/ChartLayerPanel.tsx
+++ b/packages/tools/src/components/chart/ChartLayerPanel.tsx
@@ -33,7 +33,9 @@ const toggleBtnStyle: React.CSSProperties = {
 
 const LAYER_LABELS: Record<keyof LayerVisibility, string> = {
   seamarks: 'Sea marks',
+  bathymetry: 'Depth shading',
   aisVessels: 'AIS vessels',
+  pois: 'Marinas & POIs',
   weather: 'Weather',
   rangeRings: 'Range rings',
 };

--- a/packages/tools/src/components/chart/ChartView.tsx
+++ b/packages/tools/src/components/chart/ChartView.tsx
@@ -53,15 +53,20 @@ export function ChartView({ center, zoom }: ChartViewProps) {
   const showWeather = useChartStore(s => s.layers.weather);
   const [showSeasons, setShowSeasons] = useState(false);
 
-  // Toggle OpenSeaMap layer visibility based on seamarks toggle
+  // Toggle tile layer visibility based on store
   const showSeamarks = useChartStore(s => s.layers.seamarks);
+  const showBathymetry = useChartStore(s => s.layers.bathymetry);
+  const showPois = useChartStore(s => s.layers.pois);
+
   useEffect(() => {
     if (!map || !isLoaded) return;
-    const layer = map.getLayer('openseamap-overlay');
-    if (layer) {
+    if (map.getLayer('openseamap-overlay')) {
       map.setLayoutProperty('openseamap-overlay', 'visibility', showSeamarks ? 'visible' : 'none');
     }
-  }, [map, isLoaded, showSeamarks]);
+    if (map.getLayer('gebco-bathymetry')) {
+      map.setLayoutProperty('gebco-bathymetry', 'visibility', showBathymetry ? 'visible' : 'none');
+    }
+  }, [map, isLoaded, showSeamarks, showBathymetry]);
 
   return (
     <div
@@ -77,7 +82,7 @@ export function ChartView({ center, zoom }: ChartViewProps) {
       <ChartVesselLayer map={map} isLoaded={isLoaded} />
       <ChartInfoPopup map={map} isLoaded={isLoaded} />
       <ChartLayerPanel />
-      <ChartPOILayer map={map} isLoaded={isLoaded} />
+      <ChartPOILayer map={map} isLoaded={isLoaded} visible={showPois} />
       <ChartSeasonsLayer map={map} isLoaded={isLoaded} visible={showSeasons} />
       <ChartRouteLayer map={map} isLoaded={isLoaded} />
       <ChartControls map={map} />

--- a/packages/tools/src/components/chart/chartStore.ts
+++ b/packages/tools/src/components/chart/chartStore.ts
@@ -31,6 +31,8 @@ export interface LayerVisibility {
   aisVessels: boolean;
   weather: boolean;
   rangeRings: boolean;
+  bathymetry: boolean;
+  pois: boolean;
 }
 
 export const VESSEL_TYPES = ['Sailing', 'Cargo', 'Fishing', 'Passenger', 'Tanker', 'Pleasure craft', 'Vessel'] as const;
@@ -76,7 +78,7 @@ const initialState = {
   weather: { windSpeedKnots: 0, windDirection: 0, seaState: 'calm', visibility: 'good' } as ChartWeather,
   activeRadioTarget: null as string | null,
   orientation: 'north-up' as Orientation,
-  layers: { seamarks: true, aisVessels: true, weather: true, rangeRings: true } as LayerVisibility,
+  layers: { seamarks: true, aisVessels: true, weather: true, rangeRings: true, bathymetry: false, pois: true } as LayerVisibility,
   vesselTypeFilter: { ...defaultVesselTypeFilter } as VesselTypeFilter,
   layerPanelOpen: false,
   showRangeRings: true,

--- a/packages/tools/src/components/chart/styles/blueprint-dark.json
+++ b/packages/tools/src/components/chart/styles/blueprint-dark.json
@@ -10,6 +10,13 @@
       "maxzoom": 19,
       "attribution": "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>"
     },
+    "gebco": {
+      "type": "raster",
+      "tiles": ["https://tiles.arcgis.com/tiles/C8EMgrsFcRFL6LrL/arcgis/rest/services/GEBCO_basemap_NCEI/MapServer/tile/{z}/{y}/{x}"],
+      "tileSize": 256,
+      "maxzoom": 11,
+      "attribution": "&copy; <a href='https://www.gebco.net'>GEBCO</a>"
+    },
     "openseamap": {
       "type": "raster",
       "tiles": ["https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"],
@@ -19,6 +26,17 @@
     }
   },
   "layers": [
+    {
+      "id": "gebco-bathymetry",
+      "type": "raster",
+      "source": "gebco",
+      "paint": {
+        "raster-opacity": 0.6
+      },
+      "layout": {
+        "visibility": "none"
+      }
+    },
     {
       "id": "osm-base",
       "type": "raster",


### PR DESCRIPTION
## Summary

- **GEBCO bathymetry tiles** — toggle depth shading on the chart (off by default to keep the view clean, enable via layer panel)
- **Integrated layer panel** — now controls all chart layers from one place:
  - Sea marks (OpenSeaMap)
  - Depth shading (GEBCO bathymetry)
  - AIS vessels + type filter
  - Marinas & POIs (Overpass)
  - Weather overlay
  - Range rings

## Test plan
- [ ] 34 chart tests passing
- [ ] Open chart, click ☰ to open layer panel
- [ ] Toggle "Depth shading" — blue depth contours appear on ocean areas
- [ ] Toggle "Marinas & POIs" off — POI markers disappear
- [ ] All other layer toggles still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)