### PR TITLE
Chart: unify all layers into single panel

### DIFF
--- a/packages/tools/src/components/chart/ChartLayerPanel.tsx
+++ b/packages/tools/src/components/chart/ChartLayerPanel.tsx
@@ -36,6 +36,7 @@ const LAYER_LABELS: Record<keyof LayerVisibility, string> = {
   bathymetry: 'Depth shading',
   aisVessels: 'AIS vessels',
   pois: 'Marinas & POIs',
+  seasons: 'Cruising seasons',
   weather: 'Weather',
   rangeRings: 'Range rings',
 };

--- a/packages/tools/src/components/chart/ChartView.tsx
+++ b/packages/tools/src/components/chart/ChartView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect } from 'react';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { useMap } from './useMap';
 import blueprintStyle from './styles/blueprint-dark.json';
@@ -50,23 +50,18 @@ export function ChartView({ center, zoom }: ChartViewProps) {
     style: blueprintStyle as any,
   });
   const ownPosition = useChartStore(s => s.ownPosition);
-  const showWeather = useChartStore(s => s.layers.weather);
-  const [showSeasons, setShowSeasons] = useState(false);
+  const layers = useChartStore(s => s.layers);
 
   // Toggle tile layer visibility based on store
-  const showSeamarks = useChartStore(s => s.layers.seamarks);
-  const showBathymetry = useChartStore(s => s.layers.bathymetry);
-  const showPois = useChartStore(s => s.layers.pois);
-
   useEffect(() => {
     if (!map || !isLoaded) return;
     if (map.getLayer('openseamap-overlay')) {
-      map.setLayoutProperty('openseamap-overlay', 'visibility', showSeamarks ? 'visible' : 'none');
+      map.setLayoutProperty('openseamap-overlay', 'visibility', layers.seamarks ? 'visible' : 'none');
     }
     if (map.getLayer('gebco-bathymetry')) {
-      map.setLayoutProperty('gebco-bathymetry', 'visibility', showBathymetry ? 'visible' : 'none');
+      map.setLayoutProperty('gebco-bathymetry', 'visibility', layers.bathymetry ? 'visible' : 'none');
     }
-  }, [map, isLoaded, showSeamarks, showBathymetry]);
+  }, [map, isLoaded, layers.seamarks, layers.bathymetry]);
 
   return (
     <div
@@ -82,29 +77,11 @@ export function ChartView({ center, zoom }: ChartViewProps) {
       <ChartVesselLayer map={map} isLoaded={isLoaded} />
       <ChartInfoPopup map={map} isLoaded={isLoaded} />
       <ChartLayerPanel />
-      <ChartPOILayer map={map} isLoaded={isLoaded} visible={showPois} />
-      <ChartSeasonsLayer map={map} isLoaded={isLoaded} visible={showSeasons} />
+      <ChartPOILayer map={map} isLoaded={isLoaded} visible={layers.pois} />
+      <ChartSeasonsLayer map={map} isLoaded={isLoaded} visible={layers.seasons} />
       <ChartRouteLayer map={map} isLoaded={isLoaded} />
       <ChartControls map={map} />
-      {showWeather && <ChartWeatherLayer />}
-      {/* Seasons toggle button — top-right */}
-      <button
-        onClick={() => setShowSeasons(s => !s)}
-        title={showSeasons ? 'Hide cruising seasons' : 'Show cruising seasons'}
-        aria-label="Toggle cruising seasons"
-        style={{
-          position: 'absolute', top: 8, right: 8, zIndex: 10,
-          width: 28, height: 28,
-          background: showSeasons ? 'rgba(96,165,250,0.3)' : 'rgba(0,0,0,0.6)',
-          border: `1px solid ${showSeasons ? '#60a5fa' : 'rgba(255,255,255,0.15)'}`,
-          borderRadius: 4, cursor: 'pointer',
-          color: showSeasons ? '#60a5fa' : '#8b8b9e',
-          fontFamily: "'Fira Code', monospace", fontSize: 12,
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-        }}
-      >
-        🌊
-      </button>
+      {layers.weather && <ChartWeatherLayer />}
       {/* Position overlay */}
       <div style={{
         position: 'absolute', bottom: 8, left: 8, zIndex: 10,

--- a/packages/tools/src/components/chart/chartStore.ts
+++ b/packages/tools/src/components/chart/chartStore.ts
@@ -33,6 +33,7 @@ export interface LayerVisibility {
   rangeRings: boolean;
   bathymetry: boolean;
   pois: boolean;
+  seasons: boolean;
 }
 
 export const VESSEL_TYPES = ['Sailing', 'Cargo', 'Fishing', 'Passenger', 'Tanker', 'Pleasure craft', 'Vessel'] as const;
@@ -78,7 +79,7 @@ const initialState = {
   weather: { windSpeedKnots: 0, windDirection: 0, seaState: 'calm', visibility: 'good' } as ChartWeather,
   activeRadioTarget: null as string | null,
   orientation: 'north-up' as Orientation,
-  layers: { seamarks: true, aisVessels: true, weather: true, rangeRings: true, bathymetry: false, pois: true } as LayerVisibility,
+  layers: { seamarks: true, aisVessels: true, weather: true, rangeRings: true, bathymetry: false, pois: true, seasons: false } as LayerVisibility,
   vesselTypeFilter: { ...defaultVesselTypeFilter } as VesselTypeFilter,
   layerPanelOpen: false,
   showRangeRings: true,


### PR DESCRIPTION
Move cruising seasons into the layer panel. Remove standalone toggle button. All overlays in one place.