### PR TITLE
Infra: production Go server — graceful shutdown, structured logging, timeouts (#230)

### DIFF
--- a/packages/api/cmd/server/main.go
+++ b/packages/api/cmd/server/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
-	"log"
+	"context"
+	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/curphey/above-deck/api/internal/ais"
 	"github.com/curphey/above-deck/api/internal/handler"
@@ -14,33 +18,64 @@ import (
 	"github.com/curphey/above-deck/api/internal/ws"
 )
 
+// Config holds all server configuration, loaded from environment variables.
+type Config struct {
+	Port           string
+	AllowedOrigin  string
+	AISStreamKey   string
+	AnthropicKey   string
+	LogLevel       string
+}
+
+func loadConfig() Config {
+	return Config{
+		Port:          envOr("PORT", "8080"),
+		AllowedOrigin: envOr("ALLOWED_ORIGIN", "http://localhost:4321"),
+		AISStreamKey:  os.Getenv("AISSTREAM_API_KEY"),
+		AnthropicKey:  os.Getenv("ANTHROPIC"),
+		LogLevel:      envOr("LOG_LEVEL", "info"),
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
 func main() {
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
+	cfg := loadConfig()
 
-	allowedOrigin := os.Getenv("ALLOWED_ORIGIN")
-	if allowedOrigin == "" {
-		allowedOrigin = "http://localhost:4321"
+	// Structured JSON logging
+	var logLevel slog.Level
+	switch cfg.LogLevel {
+	case "debug":
+		logLevel = slog.LevelDebug
+	case "warn":
+		logLevel = slog.LevelWarn
+	case "error":
+		logLevel = slog.LevelError
+	default:
+		logLevel = slog.LevelInfo
 	}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel}))
+	slog.SetDefault(logger)
 
-	// Set up AIS real-time feed if an API key is provided.
-	aisKey := os.Getenv("AISSTREAM_API_KEY")
-	aisClient := ais.NewClient(aisKey)
-	if aisKey != "" {
+	// AIS real-time feed
+	aisClient := ais.NewClient(cfg.AISStreamKey)
+	if cfg.AISStreamKey != "" {
 		go func() {
-			// Global bounding box — all vessels worldwide.
 			if err := aisClient.Start([2][2]float64{{-90, -180}, {90, 180}}); err != nil {
-				log.Printf("[AIS] Start error: %v", err)
+				slog.Error("AIS start failed", "error", err)
 			}
 		}()
 	}
 
+	// Core services
 	sessionMgr := session.NewManager()
 	llmClient := llm.NewClient("")
 
-	// Build tool executor with all available agent tools.
 	toolExec := tools.NewExecutor()
 	toolExec.Register(tools.NewTimeTool())
 	toolExec.Register(tools.NewWeatherTool(""))
@@ -49,11 +84,13 @@ func main() {
 	wsHub := ws.NewHub()
 	go wsHub.Run()
 
+	// Handlers
 	sessionHandler := handler.NewSessionHandler(sessionMgr, wsHub, aisClient)
 	transmitHandler := handler.NewTransmitHandler(sessionMgr, llmClient, wsHub, toolExec)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handler.Health)
+	mux.HandleFunc("GET /api/v1/health", handler.Health)
 	mux.HandleFunc("POST /api/vhf/sessions", sessionHandler.Create)
 	mux.HandleFunc("GET /api/vhf/sessions/{id}", sessionHandler.Get)
 	mux.Handle("POST /api/vhf/transmit", transmitHandler)
@@ -61,10 +98,43 @@ func main() {
 	mux.HandleFunc("GET /api/vhf/regions", handler.Regions)
 	mux.HandleFunc("GET /api/vhf/sessions/{id}/ws", ws.HandleWebSocket(wsHub))
 
-	wrapped := middleware.CORS(allowedOrigin)(mux)
+	wrapped := middleware.CORS(cfg.AllowedOrigin)(mux)
 
-	log.Printf("VHF API listening on :%s", port)
-	if err := http.ListenAndServe(":"+port, wrapped); err != nil {
-		log.Fatal(err)
+	// Server with timeouts
+	srv := &http.Server{
+		Addr:              ":" + cfg.Port,
+		Handler:           wrapped,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
+
+	// Graceful shutdown
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		slog.Info("server starting", "port", cfg.Port, "origin", cfg.AllowedOrigin)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-done
+	slog.Info("shutting down gracefully")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Stop subsystems
+	aisClient.Stop()
+	wsHub.Stop()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Error("shutdown error", "error", err)
+	}
+
+	slog.Info("server stopped")
 }

--- a/packages/api/internal/ws/hub.go
+++ b/packages/api/internal/ws/hub.go
@@ -11,6 +11,7 @@ type Hub struct {
 	clients    map[*Client]bool
 	Register   chan *Client
 	Unregister chan *Client
+	stop       chan struct{}
 	mu         sync.RWMutex
 }
 
@@ -19,6 +20,7 @@ func NewHub() *Hub {
 		clients:    make(map[*Client]bool),
 		Register:   make(chan *Client),
 		Unregister: make(chan *Client),
+		stop:       make(chan struct{}),
 	}
 }
 
@@ -36,8 +38,21 @@ func (h *Hub) Run() {
 				close(client.Send)
 			}
 			h.mu.Unlock()
+		case <-h.stop:
+			h.mu.Lock()
+			for client := range h.clients {
+				close(client.Send)
+				delete(h.clients, client)
+			}
+			h.mu.Unlock()
+			return
 		}
 	}
+}
+
+// Stop shuts down the hub and closes all client connections.
+func (h *Hub) Stop() {
+	close(h.stop)
 }
 
 func (h *Hub) Broadcast(sessionID string, message []byte) {


### PR DESCRIPTION
Hardens Go API for production: graceful shutdown, slog JSON logging, config struct, HTTP timeouts, Hub.Stop().